### PR TITLE
Fix async initiation for c++ coroutines - READ NOTES!

### DIFF
--- a/include/boost/mysql/detail/network_algorithms/impl/close_connection.hpp
+++ b/include/boost/mysql/detail/network_algorithms/impl/close_connection.hpp
@@ -41,7 +41,7 @@ struct close_op : async_op<StreamType>
   template<class Self>
   void operator()(
       Self& self,
-      error_code err
+      error_code err = {}
   )
   {
     error_code close_err;
@@ -50,7 +50,7 @@ struct close_op : async_op<StreamType>
         if (!this->get_channel().next_layer().is_open())
         {
           BOOST_ASIO_CORO_YIELD boost::asio::post(boost::beast::bind_front_handler(std::move(self)));
-          this->complete(self, error_code());
+          self.complete(error_code());
           BOOST_ASIO_CORO_YIELD break;
         }
 
@@ -62,7 +62,7 @@ struct close_op : async_op<StreamType>
                           this->get_output_info()
                       );
         close_err = this->get_channel().close();
-        this->complete(self, err ? err : close_err);
+        self.complete(err ? err : close_err);
       }
   }
 };

--- a/include/boost/mysql/detail/network_algorithms/impl/connect.hpp
+++ b/include/boost/mysql/detail/network_algorithms/impl/connect.hpp
@@ -77,7 +77,7 @@ struct connect_op : async_op<StreamType>
           {
             this->get_output_info()->set_message("Physical connect failed");
           }
-          this->complete(self, code);
+          self.complete(code);
           BOOST_ASIO_CORO_YIELD break;
         }
 
@@ -92,7 +92,7 @@ struct connect_op : async_op<StreamType>
         {
           this->get_channel().close();
         }
-        this->complete(self, code);
+        self.complete(code);
       }
   }
 };

--- a/include/boost/mysql/detail/network_algorithms/impl/execute_generic.hpp
+++ b/include/boost/mysql/detail/network_algorithms/impl/execute_generic.hpp
@@ -222,7 +222,7 @@ struct execute_generic_op : async_op<StreamType>
     // Error checking
     if (err)
     {
-      this->complete(self, err, resultset<StreamType>());
+      self.complete(err, resultset<StreamType>());
       return;
     }
 
@@ -241,7 +241,7 @@ struct execute_generic_op : async_op<StreamType>
         if (err)
         {
           conditional_assign(this->get_output_info(), std::move(info));
-          this->complete(self, err, resultset<StreamType>());
+          self.complete(err, resultset<StreamType>());
           BOOST_ASIO_CORO_YIELD break;
         }
         remaining_fields_ = processor_->field_count();
@@ -256,7 +256,7 @@ struct execute_generic_op : async_op<StreamType>
           err = processor_->process_field_definition();
           if (err)
           {
-            this->complete(self, err, resultset<StreamType>());
+            self.complete(err, resultset<StreamType>());
             BOOST_ASIO_CORO_YIELD break;
           }
 
@@ -264,10 +264,9 @@ struct execute_generic_op : async_op<StreamType>
         }
 
         // No EOF packet is expected here, as we require deprecate EOF capabilities
-        this->complete(
-            self,
+        self.complete(
             error_code(),
-            resultset_type(std::move(*processor_).create_resultset())
+            resultset<StreamType>(std::move(*processor_).create_resultset())
         );
       }
   }

--- a/include/boost/mysql/detail/network_algorithms/impl/handshake.hpp
+++ b/include/boost/mysql/detail/network_algorithms/impl/handshake.hpp
@@ -348,7 +348,7 @@ struct handshake_op : async_op<StreamType>
     // Error checking
     if (err)
     {
-      self.complete(self, err);
+      self.complete(err);
       return;
     }
 

--- a/include/boost/mysql/detail/network_algorithms/impl/read_row.hpp
+++ b/include/boost/mysql/detail/network_algorithms/impl/read_row.hpp
@@ -134,7 +134,7 @@ struct read_row_op : async_op<StreamType>
     // Error checking
     if (err)
     {
-      this->complete(self, err, result);
+      self.complete(err, result);
       return;
     }
 
@@ -156,7 +156,7 @@ struct read_row_op : async_op<StreamType>
             info
         );
         detail::conditional_assign(this->get_output_info(), std::move(info));
-        this->complete(self, err, result);
+        self.complete(err, result);
       }
   }
 };

--- a/include/boost/mysql/detail/protocol/channel.hpp
+++ b/include/boost/mysql/detail/protocol/channel.hpp
@@ -69,7 +69,11 @@ class channel
     struct read_op;
     struct write_op;
 public:
+    using executor_type = typename Stream::executor_type;
+
     channel(Stream& stream): stream_(stream) {}
+
+    executor_type get_executor() {return stream_.get_executor();}
 
     // Reading
     void read(bytestring& buffer, error_code& code);
@@ -155,10 +159,10 @@ public:
 
      // Reads from channel against the channel internal buffer, using itself as
     template<class Self>
-    void async_read(Self& self) { async_read(self, channel_.shared_buffer()); }
+    void async_read(Self&& self) { async_read(std::move(self), channel_.shared_buffer()); }
 
     template<class Self>
-    void async_read(Self& self, bytestring& buff)
+    void async_read(Self&& self, bytestring& buff)
     {
         channel_.async_read(
             buff,
@@ -167,7 +171,7 @@ public:
     }
 
     template<class Self>
-    void async_write(Self& self, const bytestring& buff)
+    void async_write(Self&& self, const bytestring& buff)
     {
         channel_.async_write(
             boost::asio::buffer(buff),
@@ -176,7 +180,7 @@ public:
     }
 
     template <class Self>
-    void async_write(Self& self) { async_write(self, channel_.shared_buffer()); }
+    void async_write(Self&& self) { async_write(std::move(self), channel_.shared_buffer()); }
 };
 
 

--- a/include/boost/mysql/detail/protocol/impl/channel.hpp
+++ b/include/boost/mysql/detail/protocol/impl/channel.hpp
@@ -258,7 +258,7 @@ struct
     // Error checking
     if (code)
     {
-      this->complete(self, code);
+      self.complete(code);
       return;
     }
 
@@ -278,7 +278,7 @@ struct
           code = chan.process_header_read(size_to_read);
           if (code)
           {
-            this->complete(self, code);
+            self.complete(code);
             BOOST_ASIO_CORO_YIELD break;
           }
 
@@ -295,7 +295,7 @@ struct
           total_transferred_size_ += bytes_transferred;
         } while (bytes_transferred == MAX_PACKET_SIZE);
 
-        this->complete(self, error_code());
+        self.complete(error_code());
       }
   }
 };
@@ -348,7 +348,7 @@ struct
     // Error handling
     if (code)
     {
-      this->complete(self, code);
+      self.complete(code);
       return;
     }
 
@@ -375,7 +375,7 @@ struct
 
         } while (total_transferred_size_ < buffer_.size());
 
-        this->complete(self, error_code());
+        self.complete(error_code());
       }
   }
 };

--- a/include/boost/mysql/impl/connection.hpp
+++ b/include/boost/mysql/impl/connection.hpp
@@ -102,7 +102,7 @@ boost::mysql::connection<Stream>::async_query(
 )
 {
     detail::conditional_clear(info);
-    detail::check_completion_token<CompletionToken, query_signature>();
+    //detail::check_completion_token<CompletionToken, query_signature>();
     return detail::async_execute_query(
         channel_,
         query_string,

--- a/include/boost/mysql/impl/connection.hpp
+++ b/include/boost/mysql/impl/connection.hpp
@@ -274,7 +274,7 @@ boost::mysql::socket_connection<Stream>::async_close(
 )
 {
     detail::conditional_clear(info);
-    detail::check_completion_token<CompletionToken, close_signature>();
+    //detail::check_completion_token<CompletionToken, close_signature>();
     return detail::async_close_connection(
         this->get_channel(),
         std::forward<CompletionToken>(token),

--- a/include/boost/mysql/impl/connection.hpp
+++ b/include/boost/mysql/impl/connection.hpp
@@ -51,7 +51,10 @@ boost::mysql::connection<Stream>::async_handshake(
 )
 {
     detail::conditional_clear(info);
-    detail::check_completion_token<CompletionToken, handshake_signature>();
+
+    // consider using: BOOST_ASIO_COMPLETION_TOKEN_FOR(sig)
+//    detail::check_completion_token<CompletionToken, handshake_signature>();
+
     return detail::async_handshake(
         channel_,
         params,

--- a/include/boost/mysql/impl/connection.hpp
+++ b/include/boost/mysql/impl/connection.hpp
@@ -234,7 +234,7 @@ boost::mysql::socket_connection<Stream>::async_connect(
 )
 {
     detail::conditional_clear(output_info);
-    detail::check_completion_token<CompletionToken, connect_signature>();
+//    detail::check_completion_token<CompletionToken, connect_signature>();
     return detail::async_connect(
         this->get_channel(),
         endpoint,

--- a/include/boost/mysql/impl/resultset.hpp
+++ b/include/boost/mysql/impl/resultset.hpp
@@ -122,6 +122,55 @@ std::vector<boost::mysql::owning_row> boost::mysql::resultset<StreamType>::fetch
     return fetch_many(std::numeric_limits<std::size_t>::max());
 }
 
+template<typename StreamType>
+struct boost::mysql::resultset<StreamType>::fetch_one_op : detail::async_op<StreamType>
+{
+  resultset<StreamType>& resultset_;
+
+  fetch_one_op(
+    detail::channel<StreamType> &chan, error_info *output_info,
+    resultset<StreamType> &obj):
+  detail::async_op<StreamType>(chan, output_info),
+  resultset_(obj)
+  {
+  }
+
+  template<class Self>
+  void operator()(
+      Self& self,
+      error_code err = {},
+      detail::read_row_result result=detail::read_row_result::error
+  )
+  {
+    BOOST_ASIO_CORO_REENTER(*this)
+      {
+        if (resultset_.complete())
+        {
+          // ensure return as if by post
+          BOOST_ASIO_CORO_YIELD boost::asio::post(std::move(self));
+          this->complete(self, error_code(), nullptr);
+          BOOST_ASIO_CORO_YIELD break;
+        }
+        BOOST_ASIO_CORO_YIELD detail::async_read_row(
+                          resultset_.deserializer_,
+                          *resultset_.channel_,
+                          resultset_.meta_.fields(),
+                          resultset_.buffer_,
+                          resultset_.current_row_.values(),
+                          resultset_.ok_packet_,
+                          std::move(self),
+                          this->get_output_info()
+                      );
+        resultset_.eof_received_ = result == detail::read_row_result::eof;
+        this->complete(
+            self,
+            err,
+            result == detail::read_row_result::row ? &resultset_.current_row_ : nullptr
+        );
+      }
+  }
+};
+
 template <typename StreamType>
 template <typename CompletionToken>
 BOOST_ASIO_INITFN_RESULT_TYPE(
@@ -133,59 +182,100 @@ boost::mysql::resultset<StreamType>::async_fetch_one(
     error_info* info
 )
 {
-    struct op: detail::async_op<StreamType, CompletionToken, fetch_one_signature, op>
-    {
-        resultset<StreamType>& resultset_;
-
-        op(
-            boost::asio::async_completion<CompletionToken, fetch_one_signature>& completion,
-            detail::channel<StreamType>& chan,
-            error_info* output_info,
-            resultset<StreamType>& obj
-        ):
-            detail::async_op<StreamType, CompletionToken, fetch_one_signature, op>(completion, chan, output_info),
-            resultset_(obj)
-        {
-        };
-
-        void operator()(
-            error_code err,
-            detail::read_row_result result=detail::read_row_result::error,
-            bool cont=true
-        )
-        {
-            BOOST_ASIO_CORO_REENTER(*this)
-            {
-                if (resultset_.complete())
-                {
-                    this->complete(cont, error_code(), nullptr);
-                    BOOST_ASIO_CORO_YIELD break;
-                }
-                BOOST_ASIO_CORO_YIELD detail::async_read_row(
-                    resultset_.deserializer_,
-                    *resultset_.channel_,
-                    resultset_.meta_.fields(),
-                    resultset_.buffer_,
-                    resultset_.current_row_.values(),
-                    resultset_.ok_packet_,
-                    std::move(*this),
-                    this->get_output_info()
-                );
-                resultset_.eof_received_ = result == detail::read_row_result::eof;
-                this->complete(
-                    cont,
-                    err,
-                    result == detail::read_row_result::row ? &resultset_.current_row_ : nullptr
-                );
-            }
-        }
-    };
-
     assert(valid());
     detail::conditional_clear(info);
-    detail::check_completion_token<CompletionToken, fetch_one_signature>();
-    return op::initiate(std::forward<CompletionToken>(token), *channel_, info, *this);
+//    detail::check_completion_token<CompletionToken, fetch_one_signature>();
+    return boost::asio::async_compose<CompletionToken, fetch_one_signature>
+        (fetch_one_op(*channel_, info, *this), token, *this);
+//    return op::initiate(std::forward<CompletionToken>(token), *channel_, info, *this);
 }
+
+template<typename StreamType>
+struct boost::mysql::resultset<StreamType>::fetch_many_op_impl
+{
+  resultset<StreamType>& parent_resultset;
+  std::vector<owning_row> rows;
+  detail::bytestring buffer;
+  std::vector<value> values;
+  std::size_t remaining;
+
+  fetch_many_op_impl(resultset<StreamType>& obj, std::size_t count):
+  parent_resultset(obj),
+  remaining(count)
+  {
+  };
+
+  void row_received()
+  {
+    rows.emplace_back(std::move(values), std::move(buffer));
+    values = std::vector<value>();
+    buffer = detail::bytestring();
+    --remaining;
+  }
+};
+
+template<typename StreamType>
+struct boost::mysql::resultset<StreamType>::fetch_many_op
+{
+  std::shared_ptr<fetch_many_op_impl> impl_;
+  bool cont_ = false;
+
+  fetch_many_op(
+      detail::channel<StreamType> &chan,
+      error_info *output_info,
+      resultset<StreamType> &obj, std::size_t count)
+      : detail::async_op<StreamType>(chan, output_info),
+        impl_(std::make_shared<fetch_many_op_impl>(obj, count))
+  {
+  };
+
+  template<class Self>
+  void operator()(
+      Self& self,
+      error_code err = {},
+      detail::read_row_result result=detail::read_row_result::error
+  )
+  {
+    BOOST_ASIO_CORO_REENTER(*this)
+      {
+        while (!impl_->parent_resultset.complete() && impl_->remaining > 0)
+        {
+          cont_ = true;
+          BOOST_ASIO_CORO_YIELD detail::async_read_row(
+                            impl_->parent_resultset.deserializer_,
+                            this->get_channel(),
+                            impl_->parent_resultset.meta_.fields(),
+                            impl_->buffer,
+                            impl_->values,
+                            impl_->parent_resultset.ok_packet_,
+                            std::move(self),
+                            this->get_output_info()
+                        );
+          if (result == detail::read_row_result::error)
+          {
+            this->complete(self, err, std::move(impl_->rows));
+            BOOST_ASIO_CORO_YIELD break;
+          }
+          else if (result == detail::read_row_result::eof)
+          {
+            impl_->parent_resultset.eof_received_ = true;
+          }
+          else
+          {
+            impl_->row_received();
+          }
+        }
+        if (!cont_) {
+          BOOST_ASIO_CORO_YIELD
+            boost::asio::post(
+              boost::beast::bind_front_handler(
+                std::move(self), err));
+        }
+
+        this->complete(self, err, std::move(impl_->rows));
+      }
+  }
+};
 
 template <typename StreamType>
 template <typename CompletionToken>
@@ -199,89 +289,14 @@ boost::mysql::resultset<StreamType>::async_fetch_many(
     error_info* info
 )
 {
-    struct op_impl
-    {
-        resultset<StreamType>& parent_resultset;
-        std::vector<owning_row> rows;
-        detail::bytestring buffer;
-        std::vector<value> values;
-        std::size_t remaining;
-
-        op_impl(resultset<StreamType>& obj, std::size_t count):
-            parent_resultset(obj),
-            remaining(count)
-        {
-        };
-
-        void row_received()
-        {
-            rows.emplace_back(std::move(values), std::move(buffer));
-            values = std::vector<value>();
-            buffer = detail::bytestring();
-            --remaining;
-        }
-    };
-
-    struct op : detail::async_op<StreamType, CompletionToken, fetch_many_signature, op>
-    {
-        std::shared_ptr<op_impl> impl_;
-
-        op(
-            boost::asio::async_completion<CompletionToken, fetch_many_signature>& completion,
-            detail::channel<StreamType>& chan,
-            error_info* output_info,
-            resultset<StreamType>& obj,
-            std::size_t count
-        ) :
-            detail::async_op<StreamType, CompletionToken, fetch_many_signature, op>(
-                    completion, chan, output_info),
-            impl_(std::make_shared<op_impl>(obj, count))
-        {
-        };
-
-        void operator()(
-            error_code err,
-            detail::read_row_result result=detail::read_row_result::error,
-            bool cont=true
-        )
-        {
-            BOOST_ASIO_CORO_REENTER(*this)
-            {
-                while (!impl_->parent_resultset.complete() && impl_->remaining > 0)
-                {
-                    BOOST_ASIO_CORO_YIELD detail::async_read_row(
-                        impl_->parent_resultset.deserializer_,
-                        this->get_channel(),
-                        impl_->parent_resultset.meta_.fields(),
-                        impl_->buffer,
-                        impl_->values,
-                        impl_->parent_resultset.ok_packet_,
-                        std::move(*this),
-                        this->get_output_info()
-                    );
-                    if (result == detail::read_row_result::error)
-                    {
-                        this->complete(cont, err, std::move(impl_->rows));
-                        BOOST_ASIO_CORO_YIELD break;
-                    }
-                    else if (result == detail::read_row_result::eof)
-                    {
-                        impl_->parent_resultset.eof_received_ = true;
-                    }
-                    else
-                    {
-                        impl_->row_received();
-                    }
-                }
-                this->complete(cont, err, std::move(impl_->rows));
-            }
-        }
-    };
-
     assert(valid());
     detail::conditional_clear(info);
-    detail::check_completion_token<CompletionToken, fetch_many_signature>();
-    return op::initiate(std::forward<CompletionToken>(token), *channel_, info, *this, count);
+    //detail::check_completion_token<CompletionToken, fetch_many_signature>();
+
+    return boost::asio::async_compose<CompletionToken, fetch_many_signature>(
+        fetch_many_op(*channel_, info, *this, count), token, *this);
+
+//    return op::initiate(std::forward<CompletionToken>(token), *channel_, info, *this, count);
 }
 
 template <typename StreamType>

--- a/include/boost/mysql/impl/resultset.hpp
+++ b/include/boost/mysql/impl/resultset.hpp
@@ -148,7 +148,7 @@ struct boost::mysql::resultset<StreamType>::fetch_one_op : detail::async_op<Stre
         {
           // ensure return as if by post
           BOOST_ASIO_CORO_YIELD boost::asio::post(std::move(self));
-          this->complete(self, error_code(), nullptr);
+          self.complete(error_code(), nullptr);
           BOOST_ASIO_CORO_YIELD break;
         }
         BOOST_ASIO_CORO_YIELD detail::async_read_row(
@@ -162,8 +162,7 @@ struct boost::mysql::resultset<StreamType>::fetch_one_op : detail::async_op<Stre
                           this->get_output_info()
                       );
         resultset_.eof_received_ = result == detail::read_row_result::eof;
-        this->complete(
-            self,
+        self.complete(
             err,
             result == detail::read_row_result::row ? &resultset_.current_row_ : nullptr
         );
@@ -215,7 +214,7 @@ struct boost::mysql::resultset<StreamType>::fetch_many_op_impl
 };
 
 template<typename StreamType>
-struct boost::mysql::resultset<StreamType>::fetch_many_op
+struct boost::mysql::resultset<StreamType>::fetch_many_op : detail::async_op<StreamType>
 {
   std::shared_ptr<fetch_many_op_impl> impl_;
   bool cont_ = false;
@@ -253,7 +252,7 @@ struct boost::mysql::resultset<StreamType>::fetch_many_op
                         );
           if (result == detail::read_row_result::error)
           {
-            this->complete(self, err, std::move(impl_->rows));
+            self.complete(err, std::move(impl_->rows));
             BOOST_ASIO_CORO_YIELD break;
           }
           else if (result == detail::read_row_result::eof)
@@ -272,7 +271,7 @@ struct boost::mysql::resultset<StreamType>::fetch_many_op
                 std::move(self), err));
         }
 
-        this->complete(self, err, std::move(impl_->rows));
+        self.complete(err, std::move(impl_->rows));
       }
   }
 };

--- a/include/boost/mysql/resultset.hpp
+++ b/include/boost/mysql/resultset.hpp
@@ -75,7 +75,12 @@ class resultset
     detail::bytestring buffer_;
     detail::ok_packet ok_packet_;
     bool eof_received_ {false};
-public:
+
+    struct fetch_one_op;
+    struct fetch_many_op;
+    struct fetch_many_op_impl;
+
+  public:
     /// Default constructor.
     resultset(): channel_(nullptr) {};
 

--- a/include/boost/mysql/resultset.hpp
+++ b/include/boost/mysql/resultset.hpp
@@ -81,6 +81,7 @@ class resultset
     struct fetch_many_op_impl;
 
   public:
+    using executor_type = typename channel_type::executor_type;
     /// Default constructor.
     resultset(): channel_(nullptr) {};
 
@@ -89,6 +90,8 @@ class resultset
         deserializer_(deserializer), channel_(&channel), meta_(std::move(meta)) {};
     resultset(channel_type& channel, detail::bytestring&& buffer, const detail::ok_packet& ok_pack):
         channel_(&channel), buffer_(std::move(buffer)), ok_packet_(ok_pack), eof_received_(true) {};
+
+    executor_type get_executor() {assert(channel_);return channel_->get_executor();}
 
     /// Retrieves the stream object associated with the underlying connection.
     StreamType& next_layer() noexcept { assert(channel_); return channel_->next_layer(); }


### PR DESCRIPTION
My son and I have done some quick and dirty surgery to ensure that async initiation is correct for all completion tokens, including use_awaitable.

I have not updated any tests, but we have tested in a program running locally.

Summary of Changes:

- Refactored async ops to use async_compose (this was easier than converting for async_initiate since none of them involved concurrent async sub-operations)
- Added executor_type and get_executor to channel and result_set types. This is necessary for async_compose and is good manners for an asio io_object in any case.
- Destroyed some of your careful formatting by accident (sorry about that).

Comments:

- Way too many little typedefs and utility base-classes. async_op in particular really has no useful purpose now that async_compose is taking care of initiation and completion hander storage and invocation.

- For library maintainers these little one-liner utilities may seem like useful packaging, but in reality they just complicate the maintenance process because they require maintainers to understand your internal api before they can do work. Sometimes it's better just to explicitly name types and call functions.
